### PR TITLE
Add: HTTP status code 401 handling. If invalid: UUID, IP or Party.

### DIFF
--- a/src/Sk/SmartId/Api/SmartIdRestConnector.php
+++ b/src/Sk/SmartId/Api/SmartIdRestConnector.php
@@ -183,6 +183,11 @@ class SmartIdRestConnector implements SmartIdConnector
       throw new NotFoundException( 'User account not found for URI ' . $url );
     }
 
+    if ( 401 == $httpCode )
+    {
+      throw new SmartIdException( 'Unauthorized' );
+    }    
+
     $response = $this->getResponse( $rawResponse, $responseType );
 
     return $response;


### PR DESCRIPTION
Added HTTP status code 401 handling since currently AuthenticationRequestBuilder::startAuthenticationAndReturnSessionId() just returns empty session id and no exceptions will be thrown. 