### PR TITLE
DDS-2500 Changed isCertificateTrusted behaviour

### DIFF
--- a/src/Sk/SmartId/Api/AuthenticationResponseValidator.php
+++ b/src/Sk/SmartId/Api/AuthenticationResponseValidator.php
@@ -36,6 +36,7 @@ class AuthenticationResponseValidator
   /**
    * @param SmartIdAuthenticationResponse $authenticationResponse
    * @return SmartIdAuthenticationResult
+   * @throws \ReflectionException
    */
   public function validate( SmartIdAuthenticationResponse $authenticationResponse )
   {
@@ -140,6 +141,7 @@ class AuthenticationResponseValidator
   /**
    * @param AuthenticationCertificate $certificate
    * @return AuthenticationIdentity
+   * @throws \ReflectionException
    */
   private function constructAuthenticationIdentity( AuthenticationCertificate $certificate )
   {
@@ -225,23 +227,19 @@ class AuthenticationResponseValidator
       return false;
     }
 
-    foreach ( $this->trustedCACertificates as $trustedCACertificate )
+    if ( $this->verifyTrustedCACertificates( $certificateAsResource ) === true )
     {
-      if ( $this->verifyTrustedCACertificate( $certificateAsResource, $trustedCACertificate ) === true )
-      {
-        return true;
-      }
+      return true;
     }
     return false;
   }
 
   /**
    * @param resource $certificateAsResource
-   * @param string $trustedCACertificate
    * @return int
    */
-  private function verifyTrustedCACertificate( $certificateAsResource, $trustedCACertificate )
+  private function verifyTrustedCACertificates( $certificateAsResource )
   {
-    return openssl_x509_checkpurpose( $certificateAsResource, X509_PURPOSE_ANY, array( $trustedCACertificate ) );
+    return openssl_x509_checkpurpose( $certificateAsResource, X509_PURPOSE_ANY, $this->trustedCACertificates );
   }
 }

--- a/tests/Sk/SmartId/Tests/Api/AuthenticationResponseValidatorTest.php
+++ b/tests/Sk/SmartId/Tests/Api/AuthenticationResponseValidatorTest.php
@@ -30,6 +30,7 @@ class AuthenticationResponseValidatorTest extends TestCase
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function validationReturnsValidAuthenticationResult()
   {
@@ -38,12 +39,12 @@ class AuthenticationResponseValidatorTest extends TestCase
 
     $this->assertTrue( $authenticationResult->isValid() );
     $this->assertTrue( empty( $authenticationResult->getErrors() ) );
-    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(),
-        $response->getCertificateInstance() );
+    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(), $response->getCertificateInstance() );
   }
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function validationReturnsValidAuthenticationResult_whenEndResultLowerCase()
   {
@@ -53,12 +54,12 @@ class AuthenticationResponseValidatorTest extends TestCase
 
     $this->assertTrue( $authenticationResult->isValid() );
     $this->assertTrue( empty( $authenticationResult->getErrors() ) );
-    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(),
-        $response->getCertificateInstance() );
+    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(), $response->getCertificateInstance() );
   }
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function validationReturnsInvalidAuthenticationResult_whenEndResultNotOk()
   {
@@ -66,14 +67,13 @@ class AuthenticationResponseValidatorTest extends TestCase
     $authenticationResult = $this->validator->validate( $response );
 
     $this->assertFalse( $authenticationResult->isValid() );
-    $this->assertTrue( in_array( SmartIdAuthenticationResultError::INVALID_END_RESULT,
-        $authenticationResult->getErrors() ) );
-    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(),
-        $response->getCertificateInstance() );
+    $this->assertTrue( in_array( SmartIdAuthenticationResultError::INVALID_END_RESULT, $authenticationResult->getErrors() ) );
+    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(), $response->getCertificateInstance() );
   }
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function validationReturnsInvalidAuthenticationResult_whenSignatureVerificationFails()
   {
@@ -81,14 +81,13 @@ class AuthenticationResponseValidatorTest extends TestCase
     $authenticationResult = $this->validator->validate( $response );
 
     $this->assertFalse( $authenticationResult->isValid() );
-    $this->assertTrue( in_array( SmartIdAuthenticationResultError::SIGNATURE_VERIFICATION_FAILURE,
-        $authenticationResult->getErrors() ) );
-    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(),
-        $response->getCertificateInstance() );
+    $this->assertTrue( in_array( SmartIdAuthenticationResultError::SIGNATURE_VERIFICATION_FAILURE, $authenticationResult->getErrors() ) );
+    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(), $response->getCertificateInstance() );
   }
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function validationReturnsInvalidAuthenticationResult_whenSignersCertNotTrusted()
   {
@@ -104,14 +103,13 @@ class AuthenticationResponseValidatorTest extends TestCase
     fclose( $tmpHandle );
 
     $this->assertFalse( $authenticationResult->isValid() );
-    $this->assertTrue( in_array( SmartIdAuthenticationResultError::CERTIFICATE_NOT_TRUSTED,
-        $authenticationResult->getErrors() ) );
-    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(),
-        $response->getCertificateInstance() );
+    $this->assertTrue( in_array( SmartIdAuthenticationResultError::CERTIFICATE_NOT_TRUSTED, $authenticationResult->getErrors() ) );
+    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(), $response->getCertificateInstance() );
   }
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function validationReturnsValidAuthenticationResult_whenCertificateLevelHigherThanRequested()
   {
@@ -120,12 +118,12 @@ class AuthenticationResponseValidatorTest extends TestCase
 
     $this->assertTrue( $authenticationResult->isValid() );
     $this->assertTrue( empty( $authenticationResult->getErrors() ) );
-    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(),
-        $response->getCertificateInstance() );
+    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(), $response->getCertificateInstance() );
   }
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function validationReturnsInvalidAuthenticationResult_whenCertificateLevelLowerThanRequested()
   {
@@ -133,14 +131,13 @@ class AuthenticationResponseValidatorTest extends TestCase
     $authenticationResult = $this->validator->validate( $response );
 
     $this->assertFalse( $authenticationResult->isValid() );
-    $this->assertTrue( in_array( SmartIdAuthenticationResultError::CERTIFICATE_LEVEL_MISMATCH,
-        $authenticationResult->getErrors() ) );
-    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(),
-        $response->getCertificateInstance() );
+    $this->assertTrue( in_array( SmartIdAuthenticationResultError::CERTIFICATE_LEVEL_MISMATCH, $authenticationResult->getErrors() ) );
+    $this->assertAuthenticationIdentityValid( $authenticationResult->getAuthenticationIdentity(), $response->getCertificateInstance() );
   }
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function withEmptyRequestedCertificateLevel_shouldPass()
   {
@@ -154,6 +151,7 @@ class AuthenticationResponseValidatorTest extends TestCase
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function withNullRequestedCertificateLevel_shouldPass()
   {
@@ -168,6 +166,7 @@ class AuthenticationResponseValidatorTest extends TestCase
   /**
    * @test
    * @expectedException \Sk\SmartId\Exception\TechnicalErrorException
+   * @throws \ReflectionException
    */
   public function whenCertificateIsNull_ThenThrowException()
   {
@@ -179,6 +178,7 @@ class AuthenticationResponseValidatorTest extends TestCase
   /**
    * @test
    * @expectedException \Sk\SmartId\Exception\TechnicalErrorException
+   * @throws \ReflectionException
    */
   public function whenSignatureIsEmpty_ThenThrowException()
   {
@@ -192,8 +192,7 @@ class AuthenticationResponseValidatorTest extends TestCase
    */
   private function createValidValidationResponse()
   {
-    return $this->createValidationResponse( SessionEndResultCode::OK, self::VALID_SIGNATURE_IN_BASE64,
-        CertificateLevelCode::QUALIFIED, CertificateLevelCode::QUALIFIED );
+    return $this->createValidationResponse( SessionEndResultCode::OK, self::VALID_SIGNATURE_IN_BASE64, CertificateLevelCode::QUALIFIED, CertificateLevelCode::QUALIFIED );
   }
 
   /**
@@ -201,8 +200,7 @@ class AuthenticationResponseValidatorTest extends TestCase
    */
   private function createValidationResponseWithInvalidEndResult()
   {
-    return $this->createValidationResponse( 'NOT OK', self::VALID_SIGNATURE_IN_BASE64, CertificateLevelCode::QUALIFIED,
-        CertificateLevelCode::QUALIFIED );
+    return $this->createValidationResponse( 'NOT OK', self::VALID_SIGNATURE_IN_BASE64, CertificateLevelCode::QUALIFIED, CertificateLevelCode::QUALIFIED );
   }
 
   /**
@@ -210,14 +208,12 @@ class AuthenticationResponseValidatorTest extends TestCase
    */
   private function createValidationResponseWithInvalidSignature()
   {
-    return $this->createValidationResponse( SessionEndResultCode::OK, self::INVALID_SIGNATURE_IN_BASE64,
-        CertificateLevelCode::QUALIFIED, CertificateLevelCode::QUALIFIED );
+    return $this->createValidationResponse( SessionEndResultCode::OK, self::INVALID_SIGNATURE_IN_BASE64, CertificateLevelCode::QUALIFIED, CertificateLevelCode::QUALIFIED );
   }
 
   private function createValidationResponseWithLowerCertificateLevelThanRequested()
   {
-    return $this->createValidationResponse( SessionEndResultCode::OK, self::VALID_SIGNATURE_IN_BASE64,
-        CertificateLevelCode::ADVANCED, CertificateLevelCode::QUALIFIED );
+    return $this->createValidationResponse( SessionEndResultCode::OK, self::VALID_SIGNATURE_IN_BASE64, CertificateLevelCode::ADVANCED, CertificateLevelCode::QUALIFIED );
   }
 
   /**
@@ -225,8 +221,7 @@ class AuthenticationResponseValidatorTest extends TestCase
    */
   private function createValidationResponseWithHigherCertificateLevelThanRequested()
   {
-    return $this->createValidationResponse( SessionEndResultCode::OK, self::VALID_SIGNATURE_IN_BASE64,
-        CertificateLevelCode::QUALIFIED, CertificateLevelCode::ADVANCED );
+    return $this->createValidationResponse( SessionEndResultCode::OK, self::VALID_SIGNATURE_IN_BASE64, CertificateLevelCode::QUALIFIED, CertificateLevelCode::ADVANCED );
   }
 
   /**
@@ -237,7 +232,7 @@ class AuthenticationResponseValidatorTest extends TestCase
    * @return SmartIdAuthenticationResponse
    */
   private function createValidationResponse( $endResult, $signatureInBase64, $certificateLevel,
-      $requestedCertificateLevel )
+                                             $requestedCertificateLevel )
   {
     $authenticationResponse = new SmartIdAuthenticationResponse();
     $authenticationResponse->setEndResult( $endResult )
@@ -249,8 +244,13 @@ class AuthenticationResponseValidatorTest extends TestCase
     return $authenticationResponse;
   }
 
+  /**
+   * @param AuthenticationIdentity $authenticationIdentity
+   * @param AuthenticationCertificate $certificate
+   * @throws \ReflectionException
+   */
   private function assertAuthenticationIdentityValid( AuthenticationIdentity $authenticationIdentity,
-      AuthenticationCertificate $certificate )
+                                                      AuthenticationCertificate $certificate )
   {
     $subject = $certificate->getSubject();
     $subjectReflection = new ReflectionClass( $subject );

--- a/tests/Sk/SmartId/Tests/Api/SmartIdClientIntegrationTest.php
+++ b/tests/Sk/SmartId/Tests/Api/SmartIdClientIntegrationTest.php
@@ -20,6 +20,7 @@ class SmartIdClientIntegrationTest extends Setup
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function authenticate_withDocumentNumber()
   {
@@ -37,6 +38,8 @@ class SmartIdClientIntegrationTest extends Setup
 
     $this->assertAuthenticationResponseCreated( $authenticationResponse, $authenticationHash->getDataToSign() );
 
+    var_dump($authenticationResponse);
+
     $authenticationResponseValidator = new AuthenticationResponseValidator( self::RESOURCES );
     $authenticationResult = $authenticationResponseValidator->validate( $authenticationResponse );
     $this->assertAuthenticationResultValid( $authenticationResult );
@@ -44,6 +47,7 @@ class SmartIdClientIntegrationTest extends Setup
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function authenticate_withNationalIdentityNumberAndCountryCode()
   {
@@ -122,6 +126,7 @@ class SmartIdClientIntegrationTest extends Setup
 
   /**
    * @test
+   * @throws \ReflectionException
    */
   public function getAuthenticationResponse_withSessionId_isComplete()
   {


### PR DESCRIPTION
Fixes #5 

removed unnecessary loop from `AuthenticationResponseValidator::isCertificateTrusted` functionality