### PR TITLE
getPublicSslKeys error fix

### DIFF
--- a/src/Sk/SmartId/Api/Authentication.php
+++ b/src/Sk/SmartId/Api/Authentication.php
@@ -62,6 +62,7 @@ class Authentication extends AbstractApi
   public function createSessionStatusFetcher()
   {
     $connector = new SmartIdRestConnector( $this->client->getHostUrl() );
+    $connector->setPublicSslKeys($this->client->getPublicSslKeys());
     $builder = new SessionStatusFetcherBuilder( $connector );
     return $builder->withSessionStatusResponseSocketTimeoutMs( $this->sessionStatusResponseSocketTimeoutMs );
   }

--- a/src/Sk/SmartId/Api/Data/SignCertificate.php
+++ b/src/Sk/SmartId/Api/Data/SignCertificate.php
@@ -1,0 +1,398 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api\Data;
+
+class SignCertificate extends PropertyMapper
+{
+  /**
+   * @var string
+   */
+  private $name;
+
+  /**
+   * @var SignCertificateSubject
+   */
+  private $subject;
+
+  /**
+   * @var string
+   */
+  private $hash;
+
+  /**
+   * @var SignCertificateIssuer
+   */
+  private $issuer;
+
+  /**
+   * @var int
+   */
+  private $version;
+
+  /**
+   * @var string
+   */
+  private $serialNumber;
+
+  /**
+   * @var string
+   */
+  private $serialNumberHex;
+
+  /**
+   * @var string
+   */
+  private $validFrom;
+
+  /**
+   * @var string
+   */
+  private $validTo;
+
+  /**
+   * @var int
+   */
+  private $validFromTimeT;
+
+  /**
+   * @var int
+   */
+  private $validToTimeT;
+
+  /**
+   * @var string
+   */
+  private $signatureTypeSN;
+
+  /**
+   * @var string
+   */
+  private $signatureTypeLN;
+
+  /**
+   * @var int
+   */
+  private $signatureTypeNID;
+
+  /**
+   * @var array
+   */
+  private $purposes;
+
+  /**
+   * @var SignCertificateExtensions
+   */
+  private $extensions;
+
+  /**
+   * @return string
+   */
+  public function getName()
+  {
+    return $this->name;
+  }
+
+  /**
+   * @param string $name
+   * @return $this
+   */
+  public function setName( $name )
+  {
+    $this->name = $name;
+    return $this;
+  }
+
+  /**
+   * @return SignCertificateSubject
+   */
+  public function getSubject()
+  {
+    return $this->subject;
+  }
+
+  /**
+   * @param SignCertificateSubject $subject
+   * @return $this
+   */
+  public function setSubject( SignCertificateSubject $subject = null )
+  {
+    $this->subject = $subject;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getHash()
+  {
+    return $this->hash;
+  }
+
+  /**
+   * @param string $hash
+   * @return $this
+   */
+  public function setHash( $hash )
+  {
+    $this->hash = $hash;
+    return $this;
+  }
+
+  /**
+   * @return SignCertificateIssuer
+   */
+  public function getIssuer()
+  {
+    return $this->issuer;
+  }
+
+  /**
+   * @param SignCertificateIssuer $issuer
+   * @return $this
+   */
+  public function setIssuer( SignCertificateIssuer $issuer = null )
+  {
+    $this->issuer = $issuer;
+    return $this;
+  }
+
+  /**
+   * @return int
+   */
+  public function getVersion()
+  {
+    return $this->version;
+  }
+
+  /**
+   * @param int $version
+   * @return $this
+   */
+  public function setVersion( $version )
+  {
+    $this->version = $version;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSerialNumber()
+  {
+    return $this->serialNumber;
+  }
+
+  /**
+   * @param string $serialNumber
+   * @return $this
+   */
+  public function setSerialNumber( $serialNumber )
+  {
+    $this->serialNumber = $serialNumber;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSerialNumberHex()
+  {
+    return $this->serialNumberHex;
+  }
+
+  /**
+   * @param string $serialNumberHex
+   * @return $this
+   */
+  public function setSerialNumberHex( $serialNumberHex )
+  {
+    $this->serialNumberHex = $serialNumberHex;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getValidFrom()
+  {
+    return $this->validFrom;
+  }
+
+  /**
+   * @param string $validFrom
+   * @return $this
+   */
+  public function setValidFrom( $validFrom )
+  {
+    $this->validFrom = $validFrom;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getValidTo()
+  {
+    return $this->validTo;
+  }
+
+  /**
+   * @param string $validTo
+   * @return $this
+   */
+  public function setValidTo( $validTo )
+  {
+    $this->validTo = $validTo;
+    return $this;
+  }
+
+  /**
+   * @return int
+   */
+  public function getValidFromTimeT()
+  {
+    return $this->validFromTimeT;
+  }
+
+  /**
+   * @param int $validFromTimeT
+   * @return $this
+   */
+  public function setValidFromTimeT( $validFromTimeT )
+  {
+    $this->validFromTimeT = $validFromTimeT;
+    return $this;
+  }
+
+  /**
+   * @return int
+   */
+  public function getValidToTimeT()
+  {
+    return $this->validToTimeT;
+  }
+
+  /**
+   * @param int $validToTimeT
+   * @return $this
+   */
+  public function setValidToTimeT( $validToTimeT )
+  {
+    $this->validToTimeT = $validToTimeT;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSignatureTypeSN()
+  {
+    return $this->signatureTypeSN;
+  }
+
+  /**
+   * @param string $signatureTypeSN
+   * @return $this
+   */
+  public function setSignatureTypeSN( $signatureTypeSN )
+  {
+    $this->signatureTypeSN = $signatureTypeSN;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSignatureTypeLN()
+  {
+    return $this->signatureTypeLN;
+  }
+
+  /**
+   * @param string $signatureTypeLN
+   * @return $this
+   */
+  public function setSignatureTypeLN( $signatureTypeLN )
+  {
+    $this->signatureTypeLN = $signatureTypeLN;
+    return $this;
+  }
+
+  /**
+   * @return int
+   */
+  public function getSignatureTypeNID()
+  {
+    return $this->signatureTypeNID;
+  }
+
+  /**
+   * @param int $signatureTypeNID
+   * @return $this
+   */
+  public function setSignatureTypeNID( $signatureTypeNID )
+  {
+    $this->signatureTypeNID = $signatureTypeNID;
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function getPurposes()
+  {
+    return $this->purposes;
+  }
+
+  /**
+   * @param array $purposes
+   * @return $this
+   */
+  public function setPurposes( array $purposes = array() )
+  {
+    $this->purposes = $purposes;
+    return $this;
+  }
+
+  /**
+   * @return SignCertificateExtensions
+   */
+  public function getExtensions()
+  {
+    return $this->extensions;
+  }
+
+  /**
+   * @param SignCertificateExtensions $extensions
+   * @return $this
+   */
+  public function setExtensions( SignCertificateExtensions $extensions = null )
+  {
+    $this->extensions = $extensions;
+    return $this;
+  }
+}

--- a/src/Sk/SmartId/Api/Data/SignCertificateExtensions.php
+++ b/src/Sk/SmartId/Api/Data/SignCertificateExtensions.php
@@ -1,0 +1,237 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api\Data;
+
+class SignCertificateExtensions extends PropertyMapper
+{
+  /**
+   * @var string
+   */
+  private $basicConstraints;
+
+  /**
+   * @var string
+   */
+  private $keyUsage;
+
+  /**
+   * @var string
+   */
+  private $certificatePolicies;
+
+  /**
+   * @var string
+   */
+  private $subjectKeyIdentifier;
+
+  /**
+   * @var string
+   */
+  private $qcStatements;
+
+  /**
+   * @var string
+   */
+  private $authorityKeyIdentifier;
+
+  /**
+   * @var string
+   */
+  private $authorityInfoAccess;
+
+  /**
+   * @var string
+   */
+  private $extendedKeyUsage;
+
+  /**
+   * @var string
+   */
+  private $subjectAltName;
+
+  /**
+   * @return string
+   */
+  public function getBasicConstraints()
+  {
+    return $this->basicConstraints;
+  }
+
+  /**
+   * @param string $basicConstraints
+   * @return $this
+   */
+  public function setBasicConstraints( $basicConstraints )
+  {
+    $this->basicConstraints = $basicConstraints;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getKeyUsage()
+  {
+    return $this->keyUsage;
+  }
+
+  /**
+   * @param string $keyUsage
+   * @return $this
+   */
+  public function setKeyUsage( $keyUsage )
+  {
+    $this->keyUsage = $keyUsage;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCertificatePolicies()
+  {
+    return $this->certificatePolicies;
+  }
+
+  /**
+   * @param string $certificatePolicies
+   * @return $this
+   */
+  public function setCertificatePolicies( $certificatePolicies )
+  {
+    $this->certificatePolicies = $certificatePolicies;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSubjectKeyIdentifier()
+  {
+    return $this->subjectKeyIdentifier;
+  }
+
+  /**
+   * @param string $subjectKeyIdentifier
+   * @return $this
+   */
+  public function setSubjectKeyIdentifier( $subjectKeyIdentifier )
+  {
+    $this->subjectKeyIdentifier = $subjectKeyIdentifier;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getQcStatements()
+  {
+    return $this->qcStatements;
+  }
+
+  /**
+   * @param string $qcStatements
+   * @return $this
+   */
+  public function setQcStatements( $qcStatements )
+  {
+    $this->qcStatements = $qcStatements;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getAuthorityKeyIdentifier()
+  {
+    return $this->authorityKeyIdentifier;
+  }
+
+  /**
+   * @param string $authorityKeyIdentifier
+   * @return $this
+   */
+  public function setAuthorityKeyIdentifier( $authorityKeyIdentifier )
+  {
+    $this->authorityKeyIdentifier = $authorityKeyIdentifier;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getAuthorityInfoAccess()
+  {
+    return $this->authorityInfoAccess;
+  }
+
+  /**
+   * @param string $authorityInfoAccess
+   * @return $this
+   */
+  public function setAuthorityInfoAccess( $authorityInfoAccess )
+  {
+    $this->authorityInfoAccess = $authorityInfoAccess;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getExtendedKeyUsage()
+  {
+    return $this->extendedKeyUsage;
+  }
+
+  /**
+   * @param string $extendedKeyUsage
+   * @return $this
+   */
+  public function setExtendedKeyUsage( $extendedKeyUsage )
+  {
+    $this->extendedKeyUsage = $extendedKeyUsage;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSubjectAltName()
+  {
+    return $this->subjectAltName;
+  }
+
+  /**
+   * @param string $subjectAltName
+   * @return $this
+   */
+  public function setSubjectAltName( $subjectAltName )
+  {
+    $this->subjectAltName = $subjectAltName;
+    return $this;
+  }
+}

--- a/src/Sk/SmartId/Api/Data/SignCertificateIssuer.php
+++ b/src/Sk/SmartId/Api/Data/SignCertificateIssuer.php
@@ -24,10 +24,99 @@
  * THE SOFTWARE.
  * #L%
  */
-namespace Sk\SmartId\Api;
+namespace Sk\SmartId\Api\Data;
 
-abstract class ApiType
+class SignCertificateIssuer extends PropertyMapper
 {
-  const AUTHENTICATION = 'authentication';
-  const SIGN = 'signature';
+  /**
+   * @var string
+   */
+  private $C;
+
+  /**
+   * @var string
+   */
+  private $O;
+
+  /**
+   * @var string
+   */
+  private $UNDEF;
+
+  /**
+   * @var string
+   */
+  private $CN;
+
+  /**
+   * @return string
+   */
+  public function getC()
+  {
+    return $this->C;
+  }
+
+  /**
+   * @param string $C
+   * @return $this
+   */
+  public function setC( $C )
+  {
+    $this->C = $C;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getO()
+  {
+    return $this->O;
+  }
+
+  /**
+   * @param string $O
+   * @return $this
+   */
+  public function setO( $O )
+  {
+    $this->O = $O;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getUNDEF()
+  {
+    return $this->UNDEF;
+  }
+
+  /**
+   * @param string $UNDEF
+   * @return $this
+   */
+  public function setUNDEF( $UNDEF )
+  {
+    $this->UNDEF = $UNDEF;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCN()
+  {
+    return $this->CN;
+  }
+
+  /**
+   * @param string $CN
+   * @return $this
+   */
+  public function setCN( $CN )
+  {
+    $this->CN = $CN;
+    return $this;
+  }
 }

--- a/src/Sk/SmartId/Api/Data/SignCertificateSubject.php
+++ b/src/Sk/SmartId/Api/Data/SignCertificateSubject.php
@@ -1,0 +1,191 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api\Data;
+
+class SignCertificateSubject extends PropertyMapper
+{
+  /**
+   * @var string
+   */
+  private $C;
+
+  /**
+   * @var string
+   */
+  private $O;
+
+  /**
+   * @var string
+   */
+  private $OU;
+
+  /**
+   * @var string
+   */
+  private $CN;
+
+  /**
+   * @var string
+   */
+  private $SN;
+
+  /**
+   * @var string
+   */
+  private $GN;
+
+  /**
+   * @var string
+   */
+  private $serialNumber;
+
+  /**
+   * @return string
+   */
+  public function getC()
+  {
+    return $this->C;
+  }
+
+  /**
+   * @param string $C
+   * @return $this
+   */
+  public function setC( $C )
+  {
+    $this->C = $C;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getO()
+  {
+    return $this->O;
+  }
+
+  /**
+   * @param string $O
+   * @return $this
+   */
+  public function setO( $O )
+  {
+    $this->O = $O;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getOU()
+  {
+    return $this->OU;
+  }
+
+  /**
+   * @param string $OU
+   * @return $this
+   */
+  public function setOU( $OU )
+  {
+    $this->OU = $OU;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCN()
+  {
+    return $this->CN;
+  }
+
+  /**
+   * @param string $CN
+   * @return $this
+   */
+  public function setCN( $CN )
+  {
+    $this->CN = $CN;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSN()
+  {
+    return $this->SN;
+  }
+
+  /**
+   * @param string $SN
+   * @return $this
+   */
+  public function setSN( $SN )
+  {
+    $this->SN = $SN;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getGN()
+  {
+    return $this->GN;
+  }
+
+  /**
+   * @param string $GN
+   * @return $this
+   */
+  public function setGN( $GN )
+  {
+    $this->GN = $GN;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSerialNumber()
+  {
+    return $this->serialNumber;
+  }
+
+  /**
+   * @param string $serialNumber
+   * @return $this
+   */
+  public function setSerialNumber( $serialNumber )
+  {
+    $this->serialNumber = $serialNumber;
+    return $this;
+  }
+}

--- a/src/Sk/SmartId/Api/Data/SignHash.php
+++ b/src/Sk/SmartId/Api/Data/SignHash.php
@@ -24,10 +24,66 @@
  * THE SOFTWARE.
  * #L%
  */
-namespace Sk\SmartId\Api;
+namespace Sk\SmartId\Api\Data;
 
-abstract class ApiType
+class SignHash extends SignableData
 {
-  const AUTHENTICATION = 'authentication';
-  const SIGN = 'signature';
+  /**
+   * @var string
+   */
+  private $hash;
+
+  /**
+   * @param string $hashType
+   * @return SignHash
+   */
+  public static function generateRandomHash( $hashType )
+  {
+    $authenticationHash = new SignHash( self::getRandomBytes() );
+    $authenticationHash->setHashType( $hashType );
+    $authenticationHash->setHash( $authenticationHash->calculateHash() );
+    return $authenticationHash;
+  }
+
+  /**
+   * @return SignHash
+   */
+  public static function generate()
+  {
+    return self::generateRandomHash( HashType::SHA512 );
+  }
+
+  /**
+   * @return string
+   */
+  private static function getRandomBytes()
+  {
+    return openssl_random_pseudo_bytes( 64 );
+  }
+
+  /**
+   * @param string $hash
+   * @return $this
+   */
+  public function setHash( $hash )
+  {
+    $this->hash = $hash;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getHash()
+  {
+    return $this->hash;
+  }
+
+  /**
+   * @return string
+   */
+  public function calculateVerificationCode()
+  {
+    return VerificationCodeCalculator::calculate( $this->hash );
+  }
 }

--- a/src/Sk/SmartId/Api/Data/SignIdentity.php
+++ b/src/Sk/SmartId/Api/Data/SignIdentity.php
@@ -1,0 +1,122 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api\Data;
+
+class SignIdentity
+{
+  /**
+   * @var string
+   */
+  private $givenName;
+
+  /**
+   * @var string
+   */
+  private $surName;
+
+  /**
+   * @var string
+   */
+  private $identityCode;
+
+  /**
+   * @var string
+   */
+  private $country;
+
+  /**
+   * @return string
+   */
+  public function getGivenName()
+  {
+    return $this->givenName;
+  }
+
+  /**
+   * @param string $givenName
+   * @return $this
+   */
+  public function setGivenName( $givenName )
+  {
+    $this->givenName = $givenName;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSurName()
+  {
+    return $this->surName;
+  }
+
+  /**
+   * @param string $surName
+   * @return $this
+   */
+  public function setSurName( $surName )
+  {
+    $this->surName = $surName;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getIdentityCode()
+  {
+    return $this->identityCode;
+  }
+
+  /**
+   * @param string $identityCode
+   * @return $this
+   */
+  public function setIdentityCode( $identityCode )
+  {
+    $this->identityCode = $identityCode;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCountry()
+  {
+    return $this->country;
+  }
+
+  /**
+   * @param string $country
+   * @return $this
+   */
+  public function setCountry( $country )
+  {
+    $this->country = $country;
+    return $this;
+  }
+}

--- a/src/Sk/SmartId/Api/Data/SignSessionRequest.php
+++ b/src/Sk/SmartId/Api/Data/SignSessionRequest.php
@@ -1,0 +1,249 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api\Data;
+
+class SignSessionRequest
+{
+  /**
+   * @var string
+   */
+  private $relyingPartyUUID;
+
+  /**
+   * @var string
+   */
+  private $relyingPartyName;
+
+  /**
+   * @var string
+   */
+  private $networkInterface;
+
+  /**
+   * @var string
+   */
+  private $certificateLevel;
+
+  /**
+   * @var string
+   */
+  private $hash;
+
+  /**
+   * @var string
+   */
+  private $hashType;
+
+  /**
+   * @var string
+   */
+  private $displayText;
+
+  /**
+   * @var string
+   */
+  private $nonce;
+
+  /**
+   * @return string
+   */
+  public function getRelyingPartyUUID()
+  {
+    return $this->relyingPartyUUID;
+  }
+
+  /**
+   * @param string $relyingPartyUUID
+   * @return $this
+   */
+  public function setRelyingPartyUUID( $relyingPartyUUID )
+  {
+    $this->relyingPartyUUID = $relyingPartyUUID;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getRelyingPartyName()
+  {
+    return $this->relyingPartyName;
+  }
+
+  /**
+   * @param string $relyingPartyName
+   * @return $this
+   */
+  public function setRelyingPartyName( $relyingPartyName )
+  {
+    $this->relyingPartyName = $relyingPartyName;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getNetworkInterface()
+  {
+    return $this->networkInterface;
+  }
+
+  /**
+   * @param string $networkInterface
+   * @return $this
+   */
+  public function setNetworkInterface( $networkInterface )
+  {
+    $this->networkInterface = $networkInterface;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCertificateLevel()
+  {
+    return $this->certificateLevel;
+  }
+
+  /**
+   * @param string $certificateLevel
+   * @return $this
+   */
+  public function setCertificateLevel( $certificateLevel )
+  {
+    $this->certificateLevel = $certificateLevel;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getHash()
+  {
+    return $this->hash;
+  }
+
+  /**
+   * @param string $hash
+   * @return $this
+   */
+  public function setHash( $hash )
+  {
+    $this->hash = $hash;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getHashType()
+  {
+    return $this->hashType;
+  }
+
+  /**
+   * @param string $hashType
+   * @return $this
+   */
+  public function setHashType( $hashType )
+  {
+    $this->hashType = $hashType;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getDisplayText()
+  {
+    return $this->displayText;
+  }
+
+  /**
+   * @param string $displayText
+   * @return $this
+   */
+  public function setDisplayText( $displayText )
+  {
+    $this->displayText = $displayText;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getNonce()
+  {
+    return $this->nonce;
+  }
+
+  /**
+   * @param string $nonce
+   * @return $this
+   */
+  public function setNonce( $nonce )
+  {
+    $this->nonce = $nonce;
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function toArray()
+  {
+    $requiredArray = array(
+        'relyingPartyUUID' => $this->relyingPartyUUID,
+        'relyingPartyName' => $this->relyingPartyName,
+        'hash'             => $this->hash,
+        'hashType'         => strtoupper( $this->hashType ),
+    );
+
+    if ( isset( $this->certificateLevel ) )
+    {
+      $requiredArray['certificateLevel'] = $this->certificateLevel;
+    }
+
+    if ( isset( $this->displayText ) )
+    {
+      $requiredArray['displayText'] = $this->displayText;
+    }
+
+    if ( isset( $this->nonce ) )
+    {
+      $requiredArray['nonce'] = $this->nonce;
+    }
+
+    if ( isset( $this->networkInterface ) )
+    {
+      $requiredArray[ 'networkInterface' ] = $this->networkInterface;
+    }
+
+    return $requiredArray;
+  }
+}

--- a/src/Sk/SmartId/Api/Data/SignSessionResponse.php
+++ b/src/Sk/SmartId/Api/Data/SignSessionResponse.php
@@ -24,10 +24,28 @@
  * THE SOFTWARE.
  * #L%
  */
-namespace Sk\SmartId\Api;
+namespace Sk\SmartId\Api\Data;
 
-abstract class ApiType
+class SignSessionResponse extends PropertyMapper
 {
-  const AUTHENTICATION = 'authentication';
-  const SIGN = 'signature';
+  /**
+   * @var string
+   */
+  private $sessionID;
+
+  /**
+   * @return string
+   */
+  public function getSessionID()
+  {
+    return $this->sessionID;
+  }
+
+  /**
+   * @param string $sessionID
+   */
+  public function setSessionID( $sessionID )
+  {
+    $this->sessionID = $sessionID;
+  }
 }

--- a/src/Sk/SmartId/Api/Data/SmartIdSignResponse.php
+++ b/src/Sk/SmartId/Api/Data/SmartIdSignResponse.php
@@ -1,0 +1,255 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api\Data;
+
+use Sk\SmartId\Exception\TechnicalErrorException;
+
+class SmartIdSignResponse extends PropertyMapper
+{
+  /**
+   * @var string
+   */
+  private $endResult;
+
+  /**
+   * @var string
+   */
+  private $signedData;
+
+  /**
+   * @var string
+   */
+  private $valueInBase64;
+
+  /**
+   * @var string
+   */
+  private $algorithmName;
+
+  /**
+   * @var string
+   */
+  private $certificate;
+
+  /**
+   * @var string
+   */
+  private $requestedCertificateLevel;
+
+  /**
+   * @var string
+   */
+  private $certificateLevel;
+
+  /**
+   * @var string
+   */
+  private $state;
+
+  /**
+   * @return string
+   */
+  public function getEndResult()
+  {
+    return $this->endResult;
+  }
+
+  /**
+   * @param string $endResult
+   * @return $this
+   */
+  public function setEndResult( $endResult )
+  {
+    $this->endResult = $endResult;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSignedData()
+  {
+    return $this->signedData;
+  }
+
+  /**
+   * @param string $signedData
+   * @return $this
+   */
+  public function setSignedData( $signedData )
+  {
+    $this->signedData = $signedData;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getValueInBase64()
+  {
+    return $this->valueInBase64;
+  }
+
+  /**
+   * @param string $valueInBase64
+   * @return $this
+   */
+  public function setValueInBase64( $valueInBase64 )
+  {
+    $this->valueInBase64 = $valueInBase64;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getAlgorithmName()
+  {
+    return $this->algorithmName;
+  }
+
+  /**
+   * @param string $algorithmName
+   * @return $this
+   */
+  public function setAlgorithmName( $algorithmName )
+  {
+    $this->algorithmName = $algorithmName;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCertificate()
+  {
+    return $this->certificate;
+  }
+
+  /**
+   * @return array
+   */
+  public function getParsedCertificate()
+  {
+    return CertificateParser::parseX509Certificate( $this->certificate );
+  }
+
+  /**
+   * @return SignCertificate
+   */
+  public function getCertificateInstance()
+  {
+    $parsed = CertificateParser::parseX509Certificate( $this->certificate );
+    return new SignCertificate( $parsed );
+  }
+
+  /**
+   * @param string $certificate
+   * @return $this
+   */
+  public function setCertificate( $certificate )
+  {
+    $this->certificate = $certificate;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCertificateLevel()
+  {
+    return $this->certificateLevel;
+  }
+
+  /**
+   * @param string $certificateLevel
+   * @return $this
+   */
+  public function setCertificateLevel( $certificateLevel )
+  {
+    $this->certificateLevel = $certificateLevel;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getRequestedCertificateLevel()
+  {
+    return $this->requestedCertificateLevel;
+  }
+
+  /**
+   * @param string $requestedCertificateLevel
+   * @return $this
+   */
+  public function setRequestedCertificateLevel( $requestedCertificateLevel )
+  {
+    $this->requestedCertificateLevel = $requestedCertificateLevel;
+    return $this;
+  }
+
+  /**
+   * @throws TechnicalErrorException
+   * @return string
+   */
+  public function getValue()
+  {
+    if ( base64_decode( $this->valueInBase64, true ) === false )
+    {
+      throw new TechnicalErrorException( 'Failed to parse signature value in base64. Probably incorrectly 
+                encoded base64 string: ' . $this->valueInBase64 );
+    }
+    return base64_decode( $this->valueInBase64, true );
+  }
+
+  /**
+   * @param string $state
+   * @return $this
+   */
+  public function setState( $state )
+  {
+    $this->state = $state;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getState()
+  {
+    return $this->state;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isRunningState()
+  {
+    return strcasecmp( SessionStatusCode::RUNNING, $this->state ) == 0;
+  }
+}

--- a/src/Sk/SmartId/Api/Data/SmartIdSignResult.php
+++ b/src/Sk/SmartId/Api/Data/SmartIdSignResult.php
@@ -24,10 +24,82 @@
  * THE SOFTWARE.
  * #L%
  */
-namespace Sk\SmartId\Api;
+namespace Sk\SmartId\Api\Data;
 
-abstract class ApiType
+class SmartIdSignResult
 {
-  const AUTHENTICATION = 'authentication';
-  const SIGN = 'signature';
+  /**
+   * @var SignIdentity
+   */
+  private $authenticationIdentity;
+
+  /**
+   * @var boolean
+   */
+  private $valid;
+
+  /**
+   * @var array
+   */
+  private $errors;
+
+  public function __construct()
+  {
+    $this->valid = true;
+    $this->errors = array();
+  }
+
+  /**
+   * @return SignIdentity
+   */
+  public function getSignIdentity()
+  {
+    return $this->authenticationIdentity;
+  }
+
+  /**
+   * @param SignIdentity $authenticationIdentity
+   * @return $this
+   */
+  public function setSignIdentity( SignIdentity $authenticationIdentity )
+  {
+    $this->authenticationIdentity = $authenticationIdentity;
+    return $this;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isValid()
+  {
+    return $this->valid;
+  }
+
+  /**
+   * @param boolean $valid
+   * @return $this
+   */
+  public function setValid( $valid )
+  {
+    $this->valid = $valid;
+    return $this;
+  }
+
+  /**
+   * @param string $error
+   * @return $this
+   */
+  public function addError( $error )
+  {
+    $this->errors[] = $error;
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function getErrors()
+  {
+    return $this->errors;
+  }
 }

--- a/src/Sk/SmartId/Api/Data/SmartIdSignResultError.php
+++ b/src/Sk/SmartId/Api/Data/SmartIdSignResultError.php
@@ -24,10 +24,13 @@
  * THE SOFTWARE.
  * #L%
  */
-namespace Sk\SmartId\Api;
+namespace Sk\SmartId\Api\Data;
 
-abstract class ApiType
+class SmartIdSignResultError
 {
-  const AUTHENTICATION = 'authentication';
-  const SIGN = 'signature';
+  const INVALID_END_RESULT = 'Response end result verification failed.';
+  const SIGNATURE_VERIFICATION_FAILURE = 'Signature verification failed.';
+  const CERTIFICATE_EXPIRED = 'Signer\'s certificate expired.';
+  const CERTIFICATE_NOT_TRUSTED = 'Signer\'s certificate is not trusted.';
+  const CERTIFICATE_LEVEL_MISMATCH = 'Signer\'s certificate level does not match with the requested level.';
 }

--- a/src/Sk/SmartId/Api/SessionStatusFetcherBuilder.php
+++ b/src/Sk/SmartId/Api/SessionStatusFetcherBuilder.php
@@ -136,6 +136,15 @@ class SessionStatusFetcherBuilder
   }
 
   /**
+   * @return Data\SmartIdSignResponse
+   */
+  public function getSignResponse()
+  {
+    return $this->build()
+        ->getSignResponse();
+  }
+
+  /**
    * @return SessionStatusFetcher
    */
   public function build()

--- a/src/Sk/SmartId/Api/Sign.php
+++ b/src/Sk/SmartId/Api/Sign.php
@@ -1,0 +1,120 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api;
+
+use Sk\SmartId\Exception\TechnicalErrorException;
+
+class Sign extends AbstractApi
+{
+  /**
+   * In milliseconds
+   * @var int
+   */
+  private $pollingSleepTimeoutMs = 1000;
+
+  /**
+   * In milliseconds
+   * @var int
+   */
+  private $sessionStatusResponseSocketTimeoutMs;
+
+  /**
+   * @return SignRequestBuilder
+   */
+  public function createSign()
+  {
+    $connector = new SmartIdRestConnector( $this->client->getHostUrl() );
+    $connector->setPublicSslKeys($this->client->getPublicSslKeys());
+    $sessionStatusPoller = $this->createSessionStatusPoller( $connector );
+    $builder = new SignRequestBuilder( $connector, $sessionStatusPoller );
+    $this->populateBuilderFields( $builder );
+
+    return $builder;
+  }
+
+  /**
+   * @return SessionStatusFetcherBuilder
+   */
+  public function createSessionStatusFetcher()
+  {
+    $connector = new SmartIdRestConnector( $this->client->getHostUrl() );
+    $connector->setPublicSslKeys($this->client->getPublicSslKeys());
+    $builder = new SessionStatusFetcherBuilder( $connector );
+    return $builder->withSessionStatusResponseSocketTimeoutMs( $this->sessionStatusResponseSocketTimeoutMs );
+  }
+
+  /**
+   * @param SmartIdRequestBuilder $builder
+   */
+  private function populateBuilderFields( SmartIdRequestBuilder $builder )
+  {
+    $builder->withRelyingPartyUUID( $this->client->getRelyingPartyUUID() )
+        ->withRelyingPartyName( $this->client->getRelyingPartyName() );
+  }
+
+  /**
+   * @param SmartIdRestConnector $connector
+   * @return SessionStatusPoller
+   */
+  private function createSessionStatusPoller( SmartIdRestConnector $connector )
+  {
+    $sessionStatusPoller = new SessionStatusPoller( $connector );
+    $sessionStatusPoller->setPollingSleepTimeoutMs( $this->pollingSleepTimeoutMs );
+    $sessionStatusPoller->setSessionStatusResponseSocketTimeoutMs( $this->sessionStatusResponseSocketTimeoutMs );
+    return $sessionStatusPoller;
+  }
+
+  /**
+   * @param int $pollingSleepTimeoutMs
+   * @throws TechnicalErrorException
+   * @return $this
+   */
+  public function setPollingSleepTimeoutMs( $pollingSleepTimeoutMs )
+  {
+    if ( $pollingSleepTimeoutMs < 0 )
+    {
+      throw new TechnicalErrorException( 'Timeout can not be negative' );
+    }
+    $this->pollingSleepTimeoutMs = $pollingSleepTimeoutMs;
+    return $this;
+  }
+
+  /**
+   * @param int $sessionStatusResponseSocketTimeoutMs
+   * @throws TechnicalErrorException
+   * @return $this
+   */
+  public function setSessionStatusResponseSocketTimeoutMs( $sessionStatusResponseSocketTimeoutMs )
+  {
+    if ( $sessionStatusResponseSocketTimeoutMs < 0 )
+    {
+      throw new TechnicalErrorException( 'Timeout can not be negative' );
+    }
+    $this->sessionStatusResponseSocketTimeoutMs = $sessionStatusResponseSocketTimeoutMs;
+    return $this;
+  }
+}

--- a/src/Sk/SmartId/Api/SignRequestBuilder.php
+++ b/src/Sk/SmartId/Api/SignRequestBuilder.php
@@ -1,0 +1,394 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api;
+
+use Sk\SmartId\Api\Data\SignHash;
+use Sk\SmartId\Api\Data\SignSessionRequest;
+use Sk\SmartId\Api\Data\SignSessionResponse;
+
+use Sk\SmartId\Api\Data\NationalIdentity;
+use Sk\SmartId\Api\Data\SessionStatus;
+use Sk\SmartId\Api\Data\SignableData;
+use Sk\SmartId\Api\Data\SmartIdSignResponse;
+use Sk\SmartId\Exception\InvalidParametersException;
+use Sk\SmartId\Exception\TechnicalErrorException;
+
+class SignRequestBuilder extends SmartIdRequestBuilder
+{
+  /**
+   * @var string
+   */
+  private $countryCode;
+
+  /**
+   * @var string
+   */
+  private $nationalIdentityNumber;
+
+  /**
+   * @var NationalIdentity
+   */
+  private $nationalIdentity;
+
+  /**
+   * @var string
+   */
+  private $documentNumber;
+
+  /**
+   * @var string
+   */
+  private $certificateLevel;
+
+  /**
+   * @var SignableData
+   */
+  private $dataToSign;
+
+  /**
+   * @var SignHash
+   */
+  private $authenticationHash;
+
+  /**
+   * @var string
+   */
+  private $displayText;
+
+  /**
+   * @var string
+   */
+  private $nonce;
+
+  /**
+   * @param SmartIdConnector $connector
+   * @param SessionStatusPoller $sessionStatusPoller
+   */
+  public function __construct( SmartIdConnector $connector, SessionStatusPoller $sessionStatusPoller )
+  {
+    parent::__construct( $connector, $sessionStatusPoller );
+  }
+
+  /**
+   * @param string $documentNumber
+   * @return $this
+   */
+  public function withDocumentNumber( $documentNumber )
+  {
+    $this->documentNumber = $documentNumber;
+    return $this;
+  }
+
+  /**
+   * @param NationalIdentity $nationalIdentity
+   * @return $this
+   */
+  public function withNationalIdentity( NationalIdentity $nationalIdentity )
+  {
+    $this->nationalIdentity = $nationalIdentity;
+    return $this;
+  }
+
+  /**
+   * @param string $countryCode
+   * @return $this
+   */
+  public function withCountryCode( $countryCode )
+  {
+    $this->countryCode = $countryCode;
+    return $this;
+  }
+
+  /**
+   * @param string $nationalIdentityNumber
+   * @return $this
+   */
+  public function withNationalIdentityNumber( $nationalIdentityNumber )
+  {
+    $this->nationalIdentityNumber = $nationalIdentityNumber;
+    return $this;
+  }
+
+  /**
+   * @param SignableData $dataToSign
+   * @return $this
+   */
+  public function withSignableData( SignableData $dataToSign )
+  {
+    $this->dataToSign = $dataToSign;
+    return $this;
+  }
+
+  /**
+   * @param SignHash $authenticationHash
+   * @return $this
+   */
+  public function withSignHash( SignHash $authenticationHash )
+  {
+    $this->authenticationHash = $authenticationHash;
+    return $this;
+  }
+
+  /**
+   * @param string $certificateLevel
+   * @return $this
+   */
+  public function withCertificateLevel( $certificateLevel )
+  {
+    $this->certificateLevel = $certificateLevel;
+    return $this;
+  }
+
+  /**
+   * @param string $displayText
+   * @return $this
+   */
+  public function withDisplayText( $displayText )
+  {
+    $this->displayText = $displayText;
+    return $this;
+  }
+
+  /**
+   * @param string $nonce
+   * @return $this
+   */
+  public function withNonce( $nonce )
+  {
+    $this->nonce = $nonce;
+    return $this;
+  }
+
+  /**
+   * @param string $relyingPartyUUID
+   * @return $this
+   */
+  public function withRelyingPartyUUID( $relyingPartyUUID )
+  {
+    parent::withRelyingPartyUUID( $relyingPartyUUID );
+    return $this;
+  }
+
+  /**
+   * @param string $relyingPartyName
+   * @return $this
+   */
+  public function withRelyingPartyName( $relyingPartyName )
+  {
+    parent::withRelyingPartyName( $relyingPartyName );
+    return $this;
+  }
+
+  /**
+   * @return SmartIdSignResponse
+   */
+  public function sign()
+  {
+    $response = $this->getSignResponse();
+    $sessionStatus = $this->getSessionStatusPoller()
+        ->fetchFinalSessionStatus( $response->getSessionID() );
+    $this->validateSessionStatus( $sessionStatus );
+    $authenticationResponse = $this->createSmartIdSignResponse( $sessionStatus );
+    return $authenticationResponse;
+  }
+
+  /**
+   * @return string
+   */
+  public function startSignAndReturnSessionId()
+  {
+    $response = $this->getSignResponse();
+    return $response->getSessionID();
+  }
+
+  /**
+   * @return SignSessionRequest
+   */
+  private function createSignSessionRequest()
+  {
+    $request = new SignSessionRequest();
+    $request->setRelyingPartyUUID( $this->getRelyingPartyUUID() )
+        ->setRelyingPartyName( $this->getRelyingPartyName() )
+        ->setCertificateLevel( $this->certificateLevel )
+        ->setHashType( $this->getHashTypeString() )
+        ->setHash( $this->getHashInBase64() )
+        ->setDisplayText( $this->displayText )
+        ->setNonce( $this->nonce )
+        ->setNetworkInterface( $this->getNetworkInterface() );
+    return $request;
+  }
+
+  /**
+   * @return string
+   */
+  private function getHashTypeString()
+  {
+    if ( isset( $this->hashType ) )
+    {
+      return $this->hashType;
+    }
+    else if ( isset( $this->authenticationHash ) )
+    {
+      return $this->authenticationHash->getHashType();
+    }
+    return $this->dataToSign->getHashType();
+  }
+
+  /**
+   * @return string
+   */
+  private function getHashInBase64()
+  {
+    if ( isset( $this->authenticationHash ) )
+    {
+      return $this->authenticationHash->calculateHashInBase64();
+    }
+    return $this->dataToSign->calculateHashInBase64();
+  }
+
+  /**
+   * @return SignSessionResponse
+   */
+  private function getSignResponse()
+  {
+    $this->validateParameters();
+    $request = $this->createSignSessionRequest();
+
+    if ( strlen( $this->documentNumber ) )
+    {
+      return $this->getConnector()
+          ->sign( $this->documentNumber, $request );
+    }
+    else
+    {
+      $identity = $this->getNationalIdentity();
+      return $this->getConnector()
+          ->signWithIdentity( $identity, $request );
+    }
+  }
+
+  /**
+   * @return NationalIdentity
+   */
+  private function getNationalIdentity()
+  {
+    if ( isset( $this->nationalIdentity ) )
+    {
+      return $this->nationalIdentity;
+    }
+    return new NationalIdentity( $this->countryCode, $this->nationalIdentityNumber );
+  }
+
+  /**
+   * @throws InvalidParametersException
+   */
+  protected function validateParameters()
+  {
+    parent::validateParameters();
+    if ( !isset( $this->documentNumber ) && !$this->hasNationalIdentity() )
+    {
+      throw new InvalidParametersException( 'Either document number or national identity must be set' );
+    }
+    if ( !$this->isSignableDataSet() && !$this->isSignHashSet() )
+    {
+      throw new InvalidParametersException( 'Signable data or hash with hash type must be set' );
+    }
+  }
+
+  /**
+   * @return bool
+   */
+  private function hasNationalIdentity()
+  {
+    return isset( $this->nationalIdentity ) ||
+        ( strlen( $this->countryCode ) && strlen( $this->nationalIdentityNumber ) );
+  }
+
+  /**
+   * @return bool
+   */
+  private function isSignableDataSet()
+  {
+    return isset( $this->dataToSign );
+  }
+
+  /**
+   * @return bool
+   */
+  private function isSignHashSet()
+  {
+    return isset( $this->authenticationHash );
+  }
+
+  /**
+   * @param SessionStatus $sessionStatus
+   * @throws TechnicalErrorException
+   */
+  private function validateSessionStatus( SessionStatus $sessionStatus )
+  {
+    if ( $sessionStatus->getSignature() === null )
+    {
+      throw new TechnicalErrorException( 'Signature was not present in the response' );
+    }
+    if ( $sessionStatus->getCert() === null )
+    {
+      throw new TechnicalErrorException( 'Certificate was not present in the response' );
+    }
+  }
+
+  /**
+   * @param SessionStatus $sessionStatus
+   * @return SmartIdSignResponse
+   */
+  private function createSmartIdSignResponse( SessionStatus $sessionStatus )
+  {
+    $sessionResult = $sessionStatus->getResult();
+    $sessionSignature = $sessionStatus->getSignature();
+    $sessionCertificate = $sessionStatus->getCert();
+
+    $authenticationResponse = new SmartIdSignResponse();
+    $authenticationResponse->setEndResult( $sessionResult->getEndResult() )
+        ->setSignedData( $this->getDataToSign() )
+        ->setValueInBase64( $sessionSignature->getValue() )
+        ->setAlgorithmName( $sessionSignature->getAlgorithm() )
+        ->setCertificate( $sessionCertificate->getValue() )
+        ->setCertificateLevel( $sessionCertificate->getCertificateLevel() );
+    return $authenticationResponse;
+  }
+
+  /**
+   * @return string
+   */
+  private function getDataToSign()
+  {
+    if ( isset( $this->authenticationHash ) )
+    {
+      return $this->authenticationHash->getDataToSign();
+    }
+    return $this->dataToSign->getDataToSign();
+  }
+}

--- a/src/Sk/SmartId/Api/SignResponseValidator.php
+++ b/src/Sk/SmartId/Api/SignResponseValidator.php
@@ -1,0 +1,270 @@
+<?php
+/*-
+ * #%L
+ * Smart ID sample PHP client
+ * %%
+ * Copyright (C) 2018 - 2019 SK ID Solutions AS
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+namespace Sk\SmartId\Api;
+
+use DirectoryIterator;
+use ReflectionClass;
+use Sk\SmartId\Api\Data\SignCertificate;
+use Sk\SmartId\Api\Data\SignIdentity;
+use Sk\SmartId\Api\Data\CertificateParser;
+use Sk\SmartId\Api\Data\SessionEndResultCode;
+use Sk\SmartId\Api\Data\SmartIdSignResponse;
+use Sk\SmartId\Api\Data\SmartIdSignResult;
+use Sk\SmartId\Api\Data\SmartIdSignResultError;
+use Sk\SmartId\Exception\TechnicalErrorException;
+
+class SignResponseValidator
+{
+  /**
+   * @var array
+   */
+  private $trustedCACertificates;
+
+  /**
+   * @param string|null $resourcesLocation
+   */
+  public function __construct( $resourcesLocation = null )
+  {
+    if ( $resourcesLocation === null )
+    {
+      $resourcesLocation = __DIR__ . '/../../../resources';
+    }
+
+    $this->trustedCACertificates = array();
+    $this->initializeTrustedCACertificatesFromResources( $resourcesLocation );
+  }
+
+  /**
+   * @param SmartIdSignResponse $authenticationResponse
+   * @return SmartIdSignResult
+   * @throws \ReflectionException
+   */
+  public function validate( SmartIdSignResponse $authenticationResponse )
+  {
+    $this->validateSignResponse( $authenticationResponse );
+    $authenticationResult = new SmartIdSignResult();
+    $identity = $this->constructSignIdentity( $authenticationResponse->getCertificateInstance() );
+    $authenticationResult->setSignIdentity( $identity );
+    if ( !$this->verifyResponseEndResult( $authenticationResponse ) )
+    {
+      $authenticationResult->setValid( false );
+      $authenticationResult->addError( SmartIdSignResultError::INVALID_END_RESULT );
+    }
+    if ( !$this->verifySignature( $authenticationResponse ) )
+    {
+      $authenticationResult->setValid( false );
+      $authenticationResult->addError( SmartIdSignResultError::SIGNATURE_VERIFICATION_FAILURE );
+    }
+    if ( !$this->verifyCertificateExpiry( $authenticationResponse->getCertificateInstance() ) )
+    {
+      $authenticationResult->setValid( false );
+      $authenticationResult->addError( SmartIdSignResultError::CERTIFICATE_EXPIRED );
+    }
+    if ( !$this->isCertificateTrusted( $authenticationResponse->getCertificate() ) )
+    {
+      $authenticationResult->setValid( false );
+      $authenticationResult->addError( SmartIdSignResultError::CERTIFICATE_NOT_TRUSTED );
+    }
+    if ( !$this->verifyCertificateLevel( $authenticationResponse ) )
+    {
+      $authenticationResult->setValid( false );
+      $authenticationResult->addError( SmartIdSignResultError::CERTIFICATE_LEVEL_MISMATCH );
+    }
+    return $authenticationResult;
+  }
+
+  /**
+   * @param SmartIdSignResponse $authenticationResponse
+   * @throws TechnicalErrorException
+   */
+  private function validateSignResponse( SmartIdSignResponse $authenticationResponse )
+  {
+    if ( $authenticationResponse->getCertificate() === null )
+    {
+      throw new TechnicalErrorException( 'Certificate is not present in the authentication response' );
+    }
+    if ( empty( $authenticationResponse->getValueInBase64() ) )
+    {
+      throw new TechnicalErrorException( 'Signature is not present in the authentication response' );
+    }
+    if ( empty( $authenticationResponse->getSignedData() ) )
+    {
+      throw new TechnicalErrorException( 'Signable data is not present in the authentication response' );
+    }
+  }
+
+  /**
+   * @param SmartIdSignResponse $authenticationResponse
+   * @return bool
+   */
+  private function verifyResponseEndResult( SmartIdSignResponse $authenticationResponse )
+  {
+    return strcasecmp( SessionEndResultCode::OK, $authenticationResponse->getEndResult() ) === 0;
+  }
+
+  /**
+   * @param SmartIdSignResponse $authenticationResponse
+   * @return bool
+   */
+  private function verifySignature( SmartIdSignResponse $authenticationResponse )
+  {
+    $preparedCertificate = CertificateParser::getPemCertificate( $authenticationResponse->getCertificate() );
+    $signature = $authenticationResponse->getValue();
+    $publicKey = openssl_pkey_get_public( $preparedCertificate );
+    if ( $publicKey !== false )
+    {
+      $data = $authenticationResponse->getSignedData();
+      return openssl_verify( $data, $signature, $publicKey, OPENSSL_ALGO_SHA512 ) === 1;
+    }
+    return false;
+  }
+
+  /**
+   * @param SignCertificate $authenticationCertificate
+   * @return bool
+   */
+  private function verifyCertificateExpiry( SignCertificate $authenticationCertificate )
+  {
+    return $authenticationCertificate !== null && $authenticationCertificate->getValidTo() > time();
+  }
+
+  /**
+   * @param SmartIdSignResponse $authenticationResponse
+   * @return bool
+   */
+  private function verifyCertificateLevel( SmartIdSignResponse $authenticationResponse )
+  {
+    $certLevel = new CertificateLevel( $authenticationResponse->getCertificateLevel() );
+    $requestedCertificateLevel = $authenticationResponse->getRequestedCertificateLevel();
+    return ( empty( $requestedCertificateLevel ) ? true : $certLevel->isEqualOrAbove( $requestedCertificateLevel ) );
+  }
+
+  /**
+   * @param SignCertificate $certificate
+   * @return SignIdentity
+   * @throws \ReflectionException
+   */
+  private function constructSignIdentity( SignCertificate $certificate )
+  {
+    $identity = new SignIdentity();
+    $subject = $certificate->getSubject();
+    $subjectReflection = new ReflectionClass( $subject );
+
+    foreach ( $subjectReflection->getProperties() as $property )
+    {
+      $property->setAccessible( true );
+      if ( strcasecmp( $property->getName(), 'GN' ) === 0 )
+      {
+        $identity->setGivenName( $property->getValue( $subject ) );
+      }
+      elseif ( strcasecmp( $property->getName(), 'SN' ) === 0 )
+      {
+        $identity->setSurName( $property->getValue( $subject ) );
+      }
+      elseif ( strcasecmp( $property->getName(), 'SERIALNUMBER' ) === 0 )
+      {
+        $identity->setIdentityCode( $property->getValue( $subject ) );
+      }
+      elseif ( strcasecmp( $property->getName(), 'C' ) === 0 )
+      {
+        $identity->setCountry( $property->getValue( $subject ) );
+      }
+    }
+
+    return $identity;
+  }
+
+  /**
+   * @param string $resourcesLocation
+   */
+  private function initializeTrustedCACertificatesFromResources( $resourcesLocation )
+  {
+    foreach ( new DirectoryIterator( $resourcesLocation . '/trusted_certificates' ) as $certificateFile )
+    {
+      if ( !$certificateFile->isDir() || !$certificateFile->isDot() )
+      {
+        $this->addTrustedCACertificateLocation( $certificateFile->getPathname() );
+      }
+    }
+  }
+
+  /**
+   * @param string $certificateFileLocation
+   * @return $this
+   */
+  public function addTrustedCACertificateLocation( $certificateFileLocation )
+  {
+    $this->trustedCACertificates[] = $certificateFileLocation;
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function getTrustedCACertificates()
+  {
+    return $this->trustedCACertificates;
+  }
+
+  /**
+   * @return $this
+   */
+  public function clearTrustedCACertificates()
+  {
+    $this->trustedCACertificates = array();
+    return $this;
+  }
+
+  /**
+   * @param string $certificate
+   * @return bool
+   */
+  private function isCertificateTrusted( $certificate )
+  {
+    $certificateAsResource = openssl_x509_read( CertificateParser::getPemCertificate( $certificate ) );
+
+    if ( $certificateAsResource === false )
+    {
+      return false;
+    }
+
+    if ( $this->verifyTrustedCACertificates( $certificateAsResource ) === true )
+    {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @param resource $certificateAsResource
+   * @return int
+   */
+  private function verifyTrustedCACertificates( $certificateAsResource )
+  {
+    return openssl_x509_checkpurpose( $certificateAsResource, X509_PURPOSE_ANY, $this->trustedCACertificates );
+  }
+}

--- a/src/Sk/SmartId/Api/SmartIdConnector.php
+++ b/src/Sk/SmartId/Api/SmartIdConnector.php
@@ -31,6 +31,8 @@ use Sk\SmartId\Api\Data\AuthenticationSessionResponse;
 use Sk\SmartId\Api\Data\NationalIdentity;
 use Sk\SmartId\Api\Data\SessionStatus;
 use Sk\SmartId\Api\Data\SessionStatusRequest;
+use Sk\SmartId\Api\Data\SignSessionRequest;
+use Sk\SmartId\Api\Data\SignSessionResponse;
 use Sk\SmartId\Exception\SessionNotFoundException;
 
 interface SmartIdConnector
@@ -48,6 +50,20 @@ interface SmartIdConnector
    * @return AuthenticationSessionResponse
    */
   function authenticateWithIdentity( NationalIdentity $identity, AuthenticationSessionRequest $request );
+
+  /**
+   * @param string $documentNumber
+   * @param SignSessionRequest $request
+   * @return SignSessionResponse
+   */
+  function sign( $documentNumber, SignSessionRequest $request );
+
+  /**
+   * @param NationalIdentity $identity
+   * @param SignSessionRequest $request
+   * @return SignSessionResponse
+   */
+  function signWithIdentity( NationalIdentity $identity, SignSessionRequest $request );
 
   /**
    * @param SessionStatusRequest $request


### PR DESCRIPTION
In Curl.php line 357:

  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Type error: Argument 1 passed to Sk\SmartId\Util\Curl::setPublicSslKeys() must be of the type string, null given, called in /Users/Markas/Work/markid.application/vendor/sk-id-solutions/smart-id-php-client/src/Sk/SmartId/Api/SmartIdRe
  stConnector.php on line 177