### PR TITLE
getPublicSslKeys error fix

### DIFF
--- a/src/Sk/SmartId/Api/Authentication.php
+++ b/src/Sk/SmartId/Api/Authentication.php
@@ -62,6 +62,7 @@ class Authentication extends AbstractApi
   public function createSessionStatusFetcher()
   {
     $connector = new SmartIdRestConnector( $this->client->getHostUrl() );
+    $connector->setPublicSslKeys($this->client->getPublicSslKeys());
     $builder = new SessionStatusFetcherBuilder( $connector );
     return $builder->withSessionStatusResponseSocketTimeoutMs( $this->sessionStatusResponseSocketTimeoutMs );
   }


### PR DESCRIPTION
In Curl.php line 357:

[Symfony\Component\Debug\Exception\FatalThrowableError]
Type error: Argument 1 passed to Sk\SmartId\Util\Curl::setPublicSslKeys() must be of the type string, null given, called in /Users/Markas/Work/markid.application/vendor/sk-id-solutions/smart-id-php-client/src/Sk/SmartId/Api/SmartIdRe
stConnector.php on line 177