### PR TITLE
Fixed PSR-0 autoloading issue

### DIFF
--- a/tests/Sk/SmartId/Tests/Util/CertificateAttributeUtilTest.php
+++ b/tests/Sk/SmartId/Tests/Util/CertificateAttributeUtilTest.php
@@ -26,7 +26,7 @@
  * #L%
  */
 
-namespace Sk\SmartId\Tests\Api\Util;
+namespace Sk\SmartId\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
 use Sk\SmartId\Tests\Api\DummyData;


### PR DESCRIPTION
This PR fixes an composer `CertificateAttributeUtilTest.php` file warning where namespace doesn't comply with psr-0 standard. 

This warning triggers every time after running `composer dump-autoload`

`Class Sk\SmartId\Tests\Api\Util\CertificateAttributeUtilTest located in ./vendor/sk-id-solutions/smart-id-php-client/tests/Sk/SmartId/Tests/Util/CertificateAttributeUtilTest.php does not comply with psr-0 autoloading standard. Skipping.`